### PR TITLE
Fix ticket creation failure by enabling CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,18 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
+
+// Enable basic CORS support so the API can be accessed from different origins
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
 app.use(express.static(__dirname));
 
 let tickets = [];


### PR DESCRIPTION
## Summary
- enable simple CORS headers for API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894f77fa2608320989f1e37458d0ba3